### PR TITLE
Use failure without its derive feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,8 +11,12 @@ categories = ["os", "filesystem"]
 keywords = ["which", "which-rs", "unix", "command"]
 
 [dependencies]
-failure = "0.1.1"
 libc = "0.2.10"
+
+[dependencies.failure]
+version = "0.1.1"
+default-features = false
+features = ["std"]
 
 [dev-dependencies]
 tempdir = "0.3.4"

--- a/src/error.rs
+++ b/src/error.rs
@@ -9,15 +9,26 @@ pub struct Error {
 
 // To suppress false positives from cargo-clippy
 #[cfg_attr(feature = "cargo-clippy", allow(empty_line_after_outer_attr))]
-#[derive(Copy, Clone, Eq, PartialEq, Debug, Fail)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum ErrorKind {
-    #[fail(display = "Bad absolute path")] BadAbsolutePath,
+    BadAbsolutePath,
+    BadRelativePath,
+    CannotFindBinaryPath,
+    CannotGetCurrentDir,
+}
 
-    #[fail(display = "Bad relative path")] BadRelativePath,
+impl Fail for ErrorKind {}
 
-    #[fail(display = "Cannot find binary path")] CannotFindBinaryPath,
-
-    #[fail(display = "Cannot get current directory")] CannotGetCurrentDir,
+impl Display for ErrorKind {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        let display = match *self {
+            ErrorKind::BadAbsolutePath => "Bad absolute path",
+            ErrorKind::BadRelativePath => "Bad relative path",
+            ErrorKind::CannotFindBinaryPath => "Cannot find binary path",
+            ErrorKind::CannotGetCurrentDir => "Cannot get current directory",
+        };
+        f.write_str(display)
+    }
 }
 
 impl Fail for Error {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,7 +13,6 @@
 //!
 //! ```
 
-#[macro_use]
 extern crate failure;
 extern crate libc;
 #[cfg(test)]


### PR DESCRIPTION
This allows crates to use `which` without being "infected" by `libproc_macro`, as described here:

https://github.com/rust-lang/rust-bindgen/issues/1407#issuecomment-436057854