### PR TITLE
Make dependency on "failure" optional

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,4 +14,5 @@ cache:
 script:
   - cargo build --all
   - cargo test
+  - cargo test --no-default-features
   - cargo doc --all --no-deps

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,11 @@ libc = "0.2.10"
 version = "0.1.1"
 default-features = false
 features = ["std"]
+optional = true
 
 [dev-dependencies]
 tempdir = "0.3.4"
+
+[features]
+default = ["use_failure"]
+use_failure = ["failure"]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -26,3 +26,4 @@ build: false
 
 test_script:
   - cargo test
+  - cargo test --no-default-features

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,10 +1,14 @@
+#[cfg(feature = "use_failure")]
 use failure::{Backtrace, Context, Fail};
 use std;
 use std::fmt::{self, Display};
 
 #[derive(Debug)]
 pub struct Error {
+    #[cfg(feature = "use_failure")]
     inner: Context<ErrorKind>,
+    #[cfg(not(feature = "use_failure"))]
+    inner: ErrorKind
 }
 
 // To suppress false positives from cargo-clippy
@@ -18,6 +22,7 @@ pub enum ErrorKind {
     CannotCanonicalize,
 }
 
+#[cfg(feature = "use_failure")]
 impl Fail for ErrorKind {}
 
 impl Display for ErrorKind {
@@ -33,6 +38,7 @@ impl Display for ErrorKind {
     }
 }
 
+#[cfg(feature = "use_failure")]
 impl Fail for Error {
     fn cause(&self) -> Option<&Fail> {
         self.inner.cause()
@@ -51,18 +57,25 @@ impl Display for Error {
 
 impl Error {
     pub fn kind(&self) -> ErrorKind {
-        *self.inner.get_context()
+        #[cfg(feature = "use_failure")]
+            { *self.inner.get_context() }
+        #[cfg(not(feature = "use_failure"))]
+            { self.inner }
     }
 }
 
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {
+            #[cfg(feature = "use_failure")]
             inner: Context::new(kind),
+            #[cfg(not(feature = "use_failure"))]
+            inner: kind,
         }
     }
 }
 
+#[cfg(feature = "use_failure")]
 impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Error {
         Error { inner }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,9 +13,11 @@
 //!
 //! ```
 
+#[cfg(feature = "use_failure")]
 extern crate failure;
 extern crate libc;
 
+#[cfg(feature = "use_failure")]
 use failure::ResultExt;
 mod checker;
 mod error;
@@ -57,7 +59,11 @@ use finder::Finder;
 ///
 /// ```
 pub fn which<T: AsRef<OsStr>>(binary_name: T) -> Result<path::PathBuf> {
+    #[cfg(feature = "use_failure")]
     let cwd = env::current_dir().context(ErrorKind::CannotGetCurrentDir)?;
+    #[cfg(not(feature = "use_failure"))]
+    let cwd = env::current_dir().map_err(|_| ErrorKind::CannotGetCurrentDir)?;
+
     which_in(binary_name, env::var_os("PATH"), &cwd)
 }
 

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -293,6 +293,7 @@ fn test_which_relative_non_executable() {
 }
 
 #[test]
+#[cfg(feature = "use_failure")]
 fn test_failure() {
     let f = TestFixture::new();
 


### PR DESCRIPTION
While being compatible with `failure` is nice, the way it is currently done in this library forces the dependency on all users of this crate, even if they do not use it at all.

The biggest example of this issue is `bindgen`, the biggest dependent of this crate but which does not use `failure`, hence making everybody that uses `bindgen` depend on `failure` (and all its dependencies) for pretty much nothing.

This PR makes the dependency on `failure` optional, by creating a new `use_failure` feature that controls whether or not the dependency on `failure` is enabled.
This feature is enabled by default to avoid any breaking changes, but it can be disabled by any dependent crate that does not wish to use `failure` and can get rid of the extra dependency.

The CI configurations were also updated, so they run tests in both configurations: with and without default features enabled.