### PR TITLE
Use automatic failure feature instead of redundant use_failure

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,5 +23,4 @@ optional = true
 tempdir = "0.3.4"
 
 [features]
-default = ["use_failure"]
-use_failure = ["failure"]
+default = ["failure"]

--- a/README.md
+++ b/README.md
@@ -20,8 +20,14 @@ use which::which;
 
 let result = which::which("rustc").unwrap();
 assert_eq!(result, PathBuf::from("/usr/bin/rustc"));
-
 ```
+
+## Errors
+
+By default this crate exposes a [`failure`] based error. This is optional, disable the default
+features to get an error type implementing the standard library `Error` trait.
+
+[`failure`]: https://crates.io/crates/failure
 
 ## Documentation
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,13 +1,13 @@
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 use failure::{Backtrace, Context, Fail};
 use std;
 use std::fmt::{self, Display};
 
 #[derive(Debug)]
 pub struct Error {
-    #[cfg(feature = "use_failure")]
+    #[cfg(feature = "failure")]
     inner: Context<ErrorKind>,
-    #[cfg(not(feature = "use_failure"))]
+    #[cfg(not(feature = "failure"))]
     inner: ErrorKind,
 }
 
@@ -22,7 +22,7 @@ pub enum ErrorKind {
     CannotCanonicalize,
 }
 
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 impl Fail for ErrorKind {}
 
 impl Display for ErrorKind {
@@ -38,7 +38,7 @@ impl Display for ErrorKind {
     }
 }
 
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 impl Fail for Error {
     fn cause(&self) -> Option<&dyn Fail> {
         self.inner.cause()
@@ -60,11 +60,11 @@ impl Display for Error {
 
 impl Error {
     pub fn kind(&self) -> ErrorKind {
-        #[cfg(feature = "use_failure")]
+        #[cfg(feature = "failure")]
         {
             *self.inner.get_context()
         }
-        #[cfg(not(feature = "use_failure"))]
+        #[cfg(not(feature = "failure"))]
         {
             self.inner
         }
@@ -74,15 +74,15 @@ impl Error {
 impl From<ErrorKind> for Error {
     fn from(kind: ErrorKind) -> Error {
         Error {
-            #[cfg(feature = "use_failure")]
+            #[cfg(feature = "failure")]
             inner: Context::new(kind),
-            #[cfg(not(feature = "use_failure"))]
+            #[cfg(not(feature = "failure"))]
             inner: kind,
         }
     }
 }
 
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 impl From<Context<ErrorKind>> for Error {
     fn from(inner: Context<ErrorKind>) -> Error {
         Error { inner }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,11 +13,11 @@
 //!
 //! ```
 
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 extern crate failure;
 extern crate libc;
 
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 use failure::ResultExt;
 mod checker;
 mod error;
@@ -59,9 +59,9 @@ use finder::Finder;
 ///
 /// ```
 pub fn which<T: AsRef<OsStr>>(binary_name: T) -> Result<path::PathBuf> {
-    #[cfg(feature = "use_failure")]
+    #[cfg(feature = "failure")]
     let cwd = env::current_dir().context(ErrorKind::CannotGetCurrentDir)?;
-    #[cfg(not(feature = "use_failure"))]
+    #[cfg(not(feature = "failure"))]
     let cwd = env::current_dir().map_err(|_| ErrorKind::CannotGetCurrentDir)?;
 
     which_in(binary_name, env::var_os("PATH"), &cwd)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -293,7 +293,7 @@ fn test_which_relative_non_executable() {
 }
 
 #[test]
-#[cfg(feature = "use_failure")]
+#[cfg(feature = "failure")]
 fn test_failure() {
     let f = TestFixture::new();
 


### PR DESCRIPTION
Optional dependencies automatically becomes a feature with the same name as that dependency. So it can be used instead of creating an arbitrary extra feature, and is IMO more idiomatic.

Strictly technically speaking this PR is a breaking change. But in practice I doubt it would break any existing code. It just renames a feature that is activated by default. So for people with the defaults they won't notice. And people deactivating default features hopefully never activated `use_failure` again, since that would simply just bring them back to where they started.