### PR TITLE
Implement std::error::Error when not using failure

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -49,6 +49,9 @@ impl Fail for Error {
     }
 }
 
+#[cfg(not(feature = "failure"))]
+impl std::error::Error for Error {}
+
 impl Display for Error {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         Display::fmt(&self.inner, f)


### PR DESCRIPTION
I'm personally not a fan of using `failure` in *libraries*. Since it breaks the ecosystem into those who expose `Fail` errors and those who expose `std::error::Error` errors. Now when `failure` is optional here, it was very easy to add support for making the `which` error type a standard error.