### PR TITLE
Windows: various performance optimisations

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,9 @@ default-features = false
 features = ["std"]
 optional = true
 
+[target.'cfg(windows)'.dependencies]
+lazy_static = "1"
+
 [dev-dependencies]
 tempdir = "0.3.7"
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -3,8 +3,6 @@ use error::*;
 use helper::has_executable_extension;
 use std::env;
 use std::ffi::OsStr;
-#[cfg(windows)]
-use std::ffi::OsString;
 use std::iter;
 use std::path::{Path, PathBuf};
 
@@ -119,19 +117,35 @@ impl Finder {
     where
         P: IntoIterator<Item = PathBuf>,
     {
-        // Read PATHEXT env variable and split it into vector of String
-        let path_exts =
-            env::var_os("PATHEXT").unwrap_or(OsString::from(env::consts::EXE_EXTENSION));
-
-        let exe_extension_vec = env::split_paths(&path_exts)
-            .filter_map(|e| e.to_str().map(|e| e.to_owned()))
-            .collect::<Vec<_>>();
+        // Sample %PATHEXT%: .COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;.MSC
+        // PATH_EXTENSIONS is then [".COM", ".EXE", ".BAT", …].
+        // (In one use of PATH_EXTENSIONS we skip the dot, but in the other we need it;
+        // hence its retention.)
+        lazy_static! {
+            static ref PATH_EXTENSIONS: Vec<String> =
+                env::var("PATHEXT")
+                    .map(|pathext| {
+                        pathext.split(';')
+                            .filter_map(|s| {
+                                if s.as_bytes()[0] == b'.' {
+                                    Some(s.to_owned())
+                                } else {
+                                    // Invalid segment; just ignore it.
+                                    None
+                                }
+                            })
+                            .collect()
+                    })
+                    // PATHEXT not being set or not being a proper Unicode string is exceedingly
+                    // improbable and would probably break Windows badly. Still, don't crash:
+                    .unwrap_or(vec![]);
+        }
 
         paths
             .into_iter()
             .flat_map(move |p| -> Box<dyn Iterator<Item = _>> {
                 // Check if path already have executable extension
-                if has_executable_extension(&p, &exe_extension_vec) {
+                if has_executable_extension(&p, &PATH_EXTENSIONS) {
                     Box::new(iter::once(p))
                 } else {
                     // Appended paths with windows executable extensions.
@@ -140,15 +154,13 @@ impl Finder {
                     // c:/windows/bin.EXE
                     // c:/windows/bin.CMD
                     // ...
-                    let ps = exe_extension_vec.clone().into_iter().map(move |e| {
+                    Box::new(PATH_EXTENSIONS.iter().map(move |e| {
                         // Append the extension.
-                        let mut p = p.clone().to_path_buf().into_os_string();
+                        let mut p = p.clone().into_os_string();
                         p.push(e);
 
                         PathBuf::from(p)
-                    });
-
-                    Box::new(ps)
+                    }))
                 }
             })
     }

--- a/src/helper.rs
+++ b/src/helper.rs
@@ -1,10 +1,10 @@
 use std::path::Path;
 
 /// Check if given path has extension which in the given vector.
-pub fn has_executable_extension<T: AsRef<Path>, S: AsRef<str>>(path: T, exts_vec: &Vec<S>) -> bool {
+pub fn has_executable_extension<T: AsRef<Path>, S: AsRef<str>>(path: T, pathext: &[S]) -> bool {
     let ext = path.as_ref().extension().and_then(|e| e.to_str());
     match ext {
-        Some(ext) => exts_vec
+        Some(ext) => pathext
             .iter()
             .any(|e| ext.eq_ignore_ascii_case(&e.as_ref()[1..])),
         _ => false,
@@ -21,12 +21,12 @@ mod test {
         // Case insensitive
         assert!(has_executable_extension(
             PathBuf::from("foo.exe"),
-            &vec![".COM", ".EXE", ".CMD"]
+            &[".COM", ".EXE", ".CMD"]
         ));
 
         assert!(has_executable_extension(
             PathBuf::from("foo.CMD"),
-            &vec![".COM", ".EXE", ".CMD"]
+            &[".COM", ".EXE", ".CMD"]
         ));
     }
 
@@ -34,7 +34,7 @@ mod test {
     fn test_extension_not_in_extension_vector() {
         assert!(!has_executable_extension(
             PathBuf::from("foo.bar"),
-            &vec![".COM", ".EXE", ".CMD"]
+            &[".COM", ".EXE", ".CMD"]
         ));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,9 @@
 #[cfg(feature = "failure")]
 extern crate failure;
 extern crate libc;
+#[cfg(windows)]
+#[macro_use]
+extern crate lazy_static;
 
 #[cfg(feature = "failure")]
 use failure::ResultExt;


### PR DESCRIPTION
I’m tidying some things up on my disk now, and found this. I wrote this against 2.0.1 on December 19, 2018; I’m not sure why I didn’t open a PR at that time, but I suspect it was because I had in mind further improvements. It could also be that there were problems with what I did, or that I found a different crate that did something similar but seemed to be designed with efficiency in mind from the start. I don’t remember.

Anyway, I rebased it, and here’s this, do what you will with it—ignore it, take it as is (but please check it first), rewrite it further, &c. I don’t even remember half of what’s in it, so it’s just as well I write useful commit messages!

This patch is abandonware. I offer no support on it.

---

- Parse PATHEXT once only, with the new platform-specific dependency lazy_static. (If anyone changes PATHEXT in the middle of process invocation, I don’t even want to *know* what they’re doing.) This should reduce allocations on subsequent calls by at least 13 on a typical machine.

- Skip an unnecessary clone of that Vec, and of every item in it. That’s another dozen or so allocations saved on every call.

- Make has_executable_extension take &[S] instead of &Vec\<S\>, in line with accepted Best Practices™. There’s probably no difference in the compiled artefact, because the optimiser will already have been fixing it.

- Remove the broken PATHEXT fallback case handling. It was intended to make it support .exe if PATHEXT was missing or non-Unicode, but due to using EXE_EXTENSION ("exe") instead of EXE_SUFFIX (".exe"), it actually matched the .xe extension. I contemplated fixing that and making it use .unwrap_or_else(|| …) instead of .unwrap_or(…) to save another allocation, but decided that it was better not to include that fallback anyway: for PATHEXT to be missing or non-Unicode is a severe breach of contract, and I doubt Windows would actually work properly; so there’s no need for such a dubious fallback.

There are still further performance optimisations that can be made, most notably around performing exact allocations rather than just converting to a PathBuf and pushing bytes willy-nilly, which may require reallocation. But this lot is a good start.