### PR TITLE
replace failure with std::error:Error and thiserror

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,15 +12,7 @@ keywords = ["which", "which-rs", "unix", "command"]
 
 [dependencies]
 libc = "0.2.65"
-
-[dependencies.failure]
-version = "0.1.7"
-default-features = false
-features = ["std"]
-optional = true
+thiserror = "1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"
-
-[features]
-default = ["failure"]

--- a/README.md
+++ b/README.md
@@ -22,13 +22,6 @@ let result = which::which("rustc").unwrap();
 assert_eq!(result, PathBuf::from("/usr/bin/rustc"));
 ```
 
-## Errors
-
-By default this crate exposes a [`failure`] based error. This is optional, disable the default
-features to get an error type implementing the standard library `Error` trait.
-
-[`failure`]: https://crates.io/crates/failure
-
 ## Documentation
 
 The documentation is [available online](https://docs.rs/which/).

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,92 +1,19 @@
-#[cfg(feature = "failure")]
-use failure::{Backtrace, Context, Fail};
-use std;
-use std::fmt::{self, Display};
+use thiserror;
 
-#[derive(Debug)]
-pub struct Error {
-    #[cfg(feature = "failure")]
-    inner: Context<ErrorKind>,
-    #[cfg(not(feature = "failure"))]
-    inner: ErrorKind,
-}
+pub type Result<T> = std::result::Result<T, Error>;
 
 // To suppress false positives from cargo-clippy
 #[cfg_attr(feature = "cargo-clippy", allow(empty_line_after_outer_attr))]
-#[derive(Copy, Clone, Eq, PartialEq, Debug)]
-pub enum ErrorKind {
+#[derive(thiserror::Error, Copy, Clone, Eq, PartialEq, Debug)]
+pub enum Error {
+    #[error("bad absolute path")]
     BadAbsolutePath,
+    #[error("bad relative path")]
     BadRelativePath,
+    #[error("cannot find binary path")]
     CannotFindBinaryPath,
+    #[error("cannot get current directory")]
     CannotGetCurrentDir,
+    #[error("cannot canonicalize path")]
     CannotCanonicalize,
 }
-
-#[cfg(feature = "failure")]
-impl Fail for ErrorKind {}
-
-impl Display for ErrorKind {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        let display = match *self {
-            ErrorKind::BadAbsolutePath => "Bad absolute path",
-            ErrorKind::BadRelativePath => "Bad relative path",
-            ErrorKind::CannotFindBinaryPath => "Cannot find binary path",
-            ErrorKind::CannotGetCurrentDir => "Cannot get current directory",
-            ErrorKind::CannotCanonicalize => "Cannot canonicalize path",
-        };
-        f.write_str(display)
-    }
-}
-
-#[cfg(feature = "failure")]
-impl Fail for Error {
-    fn cause(&self) -> Option<&dyn Fail> {
-        self.inner.cause()
-    }
-
-    fn backtrace(&self) -> Option<&Backtrace> {
-        self.inner.backtrace()
-    }
-}
-
-#[cfg(not(feature = "failure"))]
-impl std::error::Error for Error {}
-
-impl Display for Error {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        Display::fmt(&self.inner, f)
-    }
-}
-
-impl Error {
-    pub fn kind(&self) -> ErrorKind {
-        #[cfg(feature = "failure")]
-        {
-            *self.inner.get_context()
-        }
-        #[cfg(not(feature = "failure"))]
-        {
-            self.inner
-        }
-    }
-}
-
-impl From<ErrorKind> for Error {
-    fn from(kind: ErrorKind) -> Error {
-        Error {
-            #[cfg(feature = "failure")]
-            inner: Context::new(kind),
-            #[cfg(not(feature = "failure"))]
-            inner: kind,
-        }
-    }
-}
-
-#[cfg(feature = "failure")]
-impl From<Context<ErrorKind>> for Error {
-    fn from(inner: Context<ErrorKind>) -> Error {
-        Error { inner }
-    }
-}
-
-pub type Result<T> = std::result::Result<T, Error>;

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -66,7 +66,7 @@ impl Finder {
             Box::new(candidates)
         } else {
             // Search binary in PATHs(defined in environment variable).
-            let p = paths.ok_or(ErrorKind::CannotFindBinaryPath)?;
+            let p = paths.ok_or(Error::CannotFindBinaryPath)?;
             let paths: Vec<_> = env::split_paths(&p).collect();
 
             let candidates = Self::path_search_candidates(path, paths).into_iter();
@@ -82,7 +82,7 @@ impl Finder {
         }
 
         // can't find any binary
-        return Err(ErrorKind::CannotFindBinaryPath.into());
+        return Err(Error::CannotFindBinaryPath.into());
     }
 
     fn cwd_search_candidates<C>(binary_name: PathBuf, cwd: C) -> impl IntoIterator<Item = PathBuf>

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,12 +13,9 @@
 //!
 //! ```
 
-#[cfg(feature = "failure")]
-extern crate failure;
 extern crate libc;
+extern crate thiserror;
 
-#[cfg(feature = "failure")]
-use failure::ResultExt;
 mod checker;
 mod error;
 mod finder;
@@ -59,10 +56,7 @@ use finder::Finder;
 ///
 /// ```
 pub fn which<T: AsRef<OsStr>>(binary_name: T) -> Result<path::PathBuf> {
-    #[cfg(feature = "failure")]
-    let cwd = env::current_dir().context(ErrorKind::CannotGetCurrentDir)?;
-    #[cfg(not(feature = "failure"))]
-    let cwd = env::current_dir().map_err(|_| ErrorKind::CannotGetCurrentDir)?;
+    let cwd = env::current_dir().map_err(|_| Error::CannotGetCurrentDir)?;
 
     which_in(binary_name, env::var_os("PATH"), &cwd)
 }
@@ -196,7 +190,7 @@ impl CanonicalPath {
         which(binary_name)
             .and_then(|p| {
                 p.canonicalize()
-                    .map_err(|_| ErrorKind::CannotCanonicalize.into())
+                    .map_err(|_| Error::CannotCanonicalize.into())
             })
             .map(|inner| CanonicalPath { inner })
     }
@@ -214,7 +208,7 @@ impl CanonicalPath {
         which_in(binary_name, paths, cwd)
             .and_then(|p| {
                 p.canonicalize()
-                    .map_err(|_| ErrorKind::CannotCanonicalize.into())
+                    .map_err(|_| Error::CannotCanonicalize.into())
             })
             .map(|inner| CanonicalPath { inner })
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -293,12 +293,10 @@ fn test_which_relative_non_executable() {
 }
 
 #[test]
-#[cfg(feature = "failure")]
 fn test_failure() {
     let f = TestFixture::new();
 
-    let run = || -> std::result::Result<PathBuf, failure::Error> {
-        // Test the conversion to failure
+    let run = || -> which::Result<PathBuf> {
         let p = _which(&f, "./b/bin")?;
         Ok(p.into_path_buf())
     };


### PR DESCRIPTION
As per discussion in https://github.com/harryfei/which-rs/issues/20, the more rustic way of representing errors and results is using `std::error::Error` and `std::result::Result` which is incompatible with the use of `failure`. This PR removes `failure` and replaces the old `ErrorKind` with the `Error` enum for which `std::error::Error` is derived using `thiserror`. This greatly simplifies error handling from a user's perspective.

Since this does modify the library's user-facing public members in a backwards-incompatible way. I would recommend the next release should have its major version number bumped after this is merged.