### PR TITLE
Support symlinked executables on Windows

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -39,14 +39,17 @@ impl ExistedChecker {
 }
 
 impl Checker for ExistedChecker {
-    #[cfg(target_os="windows")]
+    #[cfg(target_os = "windows")]
     fn is_valid(&self, path: &Path) -> bool {
         fs::symlink_metadata(path)
-            .map(|metadata| metadata.is_file())
+            .map(|metadata| {
+                let file_type = metadata.file_type();
+                file_type.is_file() || file_type.is_symlink()
+            })
             .unwrap_or(false)
     }
 
-    #[cfg(not(target_os="windows"))]
+    #[cfg(not(target_os = "windows"))]
     fn is_valid(&self, path: &Path) -> bool {
         fs::metadata(path)
             .map(|metadata| metadata.is_file())


### PR DESCRIPTION
Info
-----
The fix to support Windows Reparse Points in #23 inadvertently resulted in actual Windows symlinks being skipped. Since `fs::symlink_metadata` doesn't traverse symlinks, calling it on a symlink will result in `is_file` being false, cause `which` to incorrectly ignore the symlink.

Changes
-----
* Added an additional check for `is_symlink` in the Windows branch of the `ExistedChecker`, which correctly includes actual symlinks as well as potentially executable.

Tested
-----
* Created a symlink to a `.exe` file locally (following [these steps](https://winaero.com/blog/create-symbolic-link-windows-10-powershell/)) and confirmed that this change can detect the linked executable.
* Created a symlink to a directory and confirmed that `which` still correctly detects directories aren't executable.

Note