### PR TITLE
Remove thiserror crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,7 +12,6 @@ keywords = ["which", "which-rs", "unix", "command"]
 
 [dependencies]
 libc = "0.2.65"
-thiserror = "1.0"
 
 [dev-dependencies]
 tempdir = "0.3.7"

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,17 +1,26 @@
-use thiserror;
+use std::fmt;
 
 pub type Result<T> = std::result::Result<T, Error>;
 
-#[derive(thiserror::Error, Copy, Clone, Eq, PartialEq, Debug)]
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
 pub enum Error {
-    #[error("bad absolute path")]
     BadAbsolutePath,
-    #[error("bad relative path")]
     BadRelativePath,
-    #[error("cannot find binary path")]
     CannotFindBinaryPath,
-    #[error("cannot get current directory")]
     CannotGetCurrentDir,
-    #[error("cannot canonicalize path")]
     CannotCanonicalize,
+}
+
+impl std::error::Error for Error {}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Error::BadAbsolutePath => write!(f, "bad absolute path"),
+            Error::BadRelativePath => write!(f, "bad relative path"),
+            Error::CannotFindBinaryPath => write!(f, "cannot find binary path"),
+            Error::CannotGetCurrentDir => write!(f, "cannot get current directory"),
+            Error::CannotCanonicalize => write!(f, "cannot canonicalize path"),
+        }
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -15,7 +15,6 @@
 //! ```
 
 extern crate libc;
-extern crate thiserror;
 
 mod checker;
 mod error;


### PR DESCRIPTION
Manually implement `std::error::Error` and `std::fmt::Display` for the `Error` enum, rather than using the derived implementation from `thiserror`.
This should provide a compile time benefit, especially on slow machines.