### PR TITLE
Allow searching with regular expressions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 target
 Cargo.lock
+.vscode/

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["which", "which-rs", "unix", "command"]
 [dependencies]
 either = "1.6"
 libc = "0.2.65"
+regex = { version = "1.5.4", optional = true }
 
 [target.'cfg(windows)'.dependencies]
 lazy_static = "1"


### PR DESCRIPTION
This PR adds an optional feature to look for binaries that match a given regular expression.

**Notes**
- It's only possible to look inside a provided list of paths, and using a `/` in the regular expression won't search in the current directory.
- I'm not sure if I have enough tests. If anything is missing, please let me know!

Fixes: #39