### PR TITLE
Import std::fs with the regex feature

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -7,6 +7,8 @@ use either::Either;
 use regex::Regex;
 use std::env;
 use std::ffi::OsStr;
+#[cfg(feature = "regex")]
+use std::fs;
 use std::iter;
 use std::path::{Path, PathBuf};
 


### PR DESCRIPTION
The import was necessary when using the regex feature.

Fixes:  #41