### PR TITLE
Documentation for regex feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,3 +21,6 @@ lazy_static = "1"
 
 [dev-dependencies]
 tempdir = "0.3.7"
+
+[package.metadata.docs.rs]
+all-features = true

--- a/README.md
+++ b/README.md
@@ -10,16 +10,25 @@ A Rust equivalent of Unix command "which". Locate installed executable in cross 
 * Windows
 * macOS
 
-## Example
+## Examples
 
-To find which rustc exectable binary is using.
+1) To find which rustc executable binary is using.
 
-``` rust
-use which::which;
+    ``` rust
+    use which::which;
 
-let result = which::which("rustc").unwrap();
-assert_eq!(result, PathBuf::from("/usr/bin/rustc"));
-```
+    let result = which("rustc").unwrap();
+    assert_eq!(result, PathBuf::from("/usr/bin/rustc"));
+    ```
+
+2. After enabling the `regex` feature, find all cargo subcommand executables on the path:
+
+    ``` rust
+    use which::which_re;
+
+    which_re(Regex::new("^cargo-.*").unwrap()).unwrap()
+        .for_each(|pth| println!("{}", pth.to_string_lossy()));
+    ```
 
 ## Documentation
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -5,6 +5,8 @@ use crate::helper::has_executable_extension;
 use either::Either;
 #[cfg(feature = "regex")]
 use regex::Regex;
+#[cfg(feature = "regex")]
+use std::borrow::Borrow;
 use std::env;
 use std::ffi::OsStr;
 #[cfg(feature = "regex")]
@@ -81,7 +83,7 @@ impl Finder {
     #[cfg(feature = "regex")]
     pub fn find_re<T>(
         &self,
-        binary_regex: Regex,
+        binary_regex: impl Borrow<Regex>,
         paths: Option<T>,
         binary_checker: CompositeChecker,
     ) -> Result<impl Iterator<Item = PathBuf>>
@@ -99,7 +101,7 @@ impl Finder {
             .map(|e| e.path())
             .filter(move |p| {
                 if let Some(unicode_file_name) = p.file_name().unwrap().to_str() {
-                    binary_regex.is_match(unicode_file_name)
+                    binary_regex.borrow().is_match(unicode_file_name)
                 } else {
                     false
                 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -26,6 +26,8 @@ mod helper;
 
 #[cfg(feature = "regex")]
 use regex::Regex;
+#[cfg(feature = "regex")]
+use std::borrow::Borrow;
 use std::env;
 use std::fmt;
 use std::path;
@@ -87,7 +89,7 @@ pub fn which_all<T: AsRef<OsStr>>(binary_name: T) -> Result<impl Iterator<Item =
 /// assert_eq!(binaries, python_paths);
 /// ```
 #[cfg(feature = "regex")]
-pub fn which_re(regex: Regex) -> Result<impl Iterator<Item = path::PathBuf>> {
+pub fn which_re(regex: impl Borrow<Regex>) -> Result<impl Iterator<Item = path::PathBuf>> {
     which_re_in(regex, env::var_os("PATH"))
 }
 
@@ -124,7 +126,7 @@ where
 /// assert_eq!(binaries, python_paths);
 /// ```
 #[cfg(feature = "regex")]
-pub fn which_re_in<T>(regex: Regex, paths: Option<T>) -> Result<impl Iterator<Item = path::PathBuf>>
+pub fn which_re_in<T>(regex: impl Borrow<Regex>, paths: Option<T>) -> Result<impl Iterator<Item = path::PathBuf>>
 where
     T: AsRef<OsStr>,
 {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! use which::which;
 //! use std::path::PathBuf;
 //!
-//! let result = which::which("rustc").unwrap();
+//! let result = which("rustc").unwrap();
 //! assert_eq!(result, PathBuf::from("/usr/bin/rustc"));
 //!
 //! ```
@@ -72,11 +72,15 @@ pub fn which_all<T: AsRef<OsStr>>(binary_name: T) -> Result<impl Iterator<Item =
 
 /// Find all binaries matching a regular expression in a the system PATH.
 ///
+/// Only available when feature `regex` is enabled.
+///
 /// # Arguments
 ///
 /// * `regex` - A regular expression to match binaries with
 ///
 /// # Examples
+///
+/// Find Python executables:
 ///
 /// ```no_run
 /// use regex::Regex;
@@ -87,6 +91,16 @@ pub fn which_all<T: AsRef<OsStr>>(binary_name: T) -> Result<impl Iterator<Item =
 /// let binaries: Vec<PathBuf> = which::which_re(re).unwrap().collect();
 /// let python_paths = vec![PathBuf::from("/usr/bin/python2"), PathBuf::from("/usr/bin/python3")];
 /// assert_eq!(binaries, python_paths);
+/// ```
+///
+/// Find all cargo subcommand executables on the path:
+///
+/// ```
+/// use which::which_re;
+/// use regex::Regex;
+///
+/// which_re(Regex::new("^cargo-.*").unwrap()).unwrap()
+///     .for_each(|pth| println!("{}", pth.to_string_lossy()));
 /// ```
 #[cfg(feature = "regex")]
 pub fn which_re(regex: impl Borrow<Regex>) -> Result<impl Iterator<Item = path::PathBuf>> {
@@ -105,6 +119,8 @@ where
 }
 
 /// Find all binaries matching a regular expression in a list of paths.
+///
+/// Only available when feature `regex` is enabled.
 ///
 /// # Arguments
 ///

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -163,6 +163,15 @@ fn test_which_re_in_without_matches() {
 }
 
 #[test]
+#[cfg(all(unix, feature = "regex"))]
+fn test_which_re_accepts_owned_and_borrow() {
+    which::which_re(Regex::new(r".").unwrap());
+    which::which_re(&Regex::new(r".").unwrap());
+    which::which_re_in(Regex::new(r".").unwrap(), Some("pth"));
+    which::which_re_in(&Regex::new(r".").unwrap(), Some("pth"));
+}
+
+#[test]
 #[cfg(unix)]
 fn test_which_extension() {
     let f = TestFixture::new();


### PR DESCRIPTION
Add documentation for the regex path search feature.

Also accept `&Regex` in addition to just `Regex`.

Related to #37 and #40.