### PR TITLE
ci: Disallow warnings from `clippy`

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -46,7 +46,7 @@ jobs:
         uses: actions-rs/cargo@v1
         with:
           command: clippy
-          args: --workspace --all-targets --all-features
+          args: --workspace --all-targets --all-features -- -Dwarnings
 
   # Ensure that the project could be successfully compiled
   cargo_check:

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,7 +1,5 @@
 use crate::finder::Checker;
 #[cfg(unix)]
-use libc;
-#[cfg(unix)]
 use std::ffi::CString;
 use std::fs;
 #[cfg(unix)]
@@ -20,7 +18,7 @@ impl Checker for ExecutableChecker {
     #[cfg(unix)]
     fn is_valid(&self, path: &Path) -> bool {
         CString::new(path.as_os_str().as_bytes())
-            .and_then(|c| Ok(unsafe { libc::access(c.as_ptr(), libc::X_OK) == 0 }))
+            .map(|c| unsafe { libc::access(c.as_ptr(), libc::X_OK) == 0 })
             .unwrap_or(false)
     }
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -94,6 +94,9 @@ impl Finder {
         T: AsRef<OsStr>,
     {
         let p = paths.ok_or(Error::CannotFindBinaryPath)?;
+        // Collect needs to happen in order to not have to
+        // change the API to borrow on `paths`.
+        #[allow(clippy::needless_collect)]
         let paths: Vec<_> = env::split_paths(&p).collect();
 
         let matching_re = paths
@@ -169,7 +172,7 @@ impl Finder {
                     })
                     // PATHEXT not being set or not being a proper Unicode string is exceedingly
                     // improbable and would probably break Windows badly. Still, don't crash:
-                    .unwrap_or(vec![]);
+                    .unwrap_or_default();
         }
 
         paths


### PR DESCRIPTION
Running the `clippy` linter does not make much sense if 99% of its coverage isn't stopping the CI from succeeding.