### PR TITLE
windows: Also search for file without added extension

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -182,19 +182,25 @@ impl Finder {
                 if has_executable_extension(&p, &PATH_EXTENSIONS) {
                     Box::new(iter::once(p))
                 } else {
+                    let bare_file = p.extension().map(|_| p.clone());
                     // Appended paths with windows executable extensions.
-                    // e.g. path `c:/windows/bin` will expend to:
-                    // c:/windows/bin.COM
-                    // c:/windows/bin.EXE
-                    // c:/windows/bin.CMD
+                    // e.g. path `c:/windows/bin[.ext]` will expand to:
+                    // [c:/windows/bin.ext]
+                    // c:/windows/bin[.ext].COM
+                    // c:/windows/bin[.ext].EXE
+                    // c:/windows/bin[.ext].CMD
                     // ...
-                    Box::new(PATH_EXTENSIONS.iter().map(move |e| {
-                        // Append the extension.
-                        let mut p = p.clone().into_os_string();
-                        p.push(e);
+                    Box::new(
+                        bare_file
+                            .into_iter()
+                            .chain(PATH_EXTENSIONS.iter().map(move |e| {
+                                // Append the extension.
+                                let mut p = p.clone().into_os_string();
+                                p.push(e);
 
-                        PathBuf::from(p)
-                    }))
+                                PathBuf::from(p)
+                            })),
+                    )
                 }
             })
     }


### PR DESCRIPTION
Previously if the extension of the file to be searched for was not in the
list of executable extensions (env var `PATHEXT`), the original filename
would not be searched.
E.g. `script.py` would result in `script.py.EXE`, `script.py.COM`, and so on
to be searched.

This change prepends the original file to the search list if it already has
a file extension so that the unmodified filename will be searched as well.

Fixes #56 