### PR TITLE
Replace ancient `lazy_static` crate with `once_cell`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ libc = "0.2.121"
 regex = { version = "1.5.5", optional = true }
 
 [target.'cfg(windows)'.dependencies]
-lazy_static = "1.4.0"
+once_cell = "1"
 
 [dev-dependencies]
 tempfile = "3.3.0"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,10 +14,6 @@
 //!
 //! ```
 
-#[cfg(windows)]
-#[macro_use]
-extern crate lazy_static;
-
 mod checker;
 mod error;
 mod finder;


### PR DESCRIPTION
# Warning

This change has _not_ been run-tested, only build-tested in a crosscompiled environment.

---

Piggybacking on the [motivation in winit]: `lazy_static!` is a macro whereas `once_cell` achieves the same using generics.  Its implementation has also been [proposed for inclusion in `std`], making it easier to switch to a standardized version if/when that happens.  The author of that winit PR is making this change to many more crates, slowly turning the scales in favour of `once_cell` in most dependency trees.  Furthermore `lazy_static` hasn't published any updates for 3 years.

See also [the `once_cell` F.A.Q.].

[motivation in winit]: https://github.com/rust-windowing/winit/pull/2313
[proposed for inclusion in `std`]: https://github.com/rust-lang/rust/issues/74465
[the `once_cell` F.A.Q.]: https://docs.rs/once_cell/latest/once_cell/#faq
