### PR TITLE
Implement tilde expansion for path env

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ categories = ["os", "filesystem"]
 keywords = ["which", "which-rs", "unix", "command"]
 
 [dependencies]
+dirs = "5.0.1"
 either = "1.6.1"
 libc = "0.2.121"
 regex = { version = "1.5.5", optional = true }


### PR DESCRIPTION
Fixes #71 by expanding tilde (~) to the value of the home directory. Emulates the bash approach to tilde expansion.

This PR intentionally ignores the more complicated parts of how `bash` expands the tilde character, because I feel that path resolution using the PATH environment variable should not rely on any information about the current directory, or about the previous current directory. So, `~/dir` works, `~+/dir` does not.