### PR TITLE
Switch to rustix from libc

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ rustix = { version = "0.38.10", default-features = false, features = ["fs", "std
 once_cell = "1"
 
 [dev-dependencies]
-libc = "0.2.147"
 tempfile = "3.3.0"
 
 [package.metadata.docs.rs]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,13 +14,14 @@ keywords = ["which", "which-rs", "unix", "command"]
 [dependencies]
 dirs = "5.0.1"
 either = "1.6.1"
-libc = "0.2.121"
 regex = { version = "1.5.5", optional = true }
+rustix = { version = "0.38.10", default-features = false, features = ["fs", "std"] }
 
 [target.'cfg(windows)'.dependencies]
 once_cell = "1"
 
 [dev-dependencies]
+libc = "0.2.147"
 tempfile = "3.3.0"
 
 [package.metadata.docs.rs]

--- a/src/checker.rs
+++ b/src/checker.rs
@@ -1,11 +1,5 @@
 use crate::finder::Checker;
-#[cfg(any(unix, target_os = "wasi"))]
-use std::ffi::CString;
 use std::fs;
-#[cfg(unix)]
-use std::os::unix::ffi::OsStrExt;
-#[cfg(target_os = "wasi")]
-use std::os::wasi::ffi::OsStrExt;
 use std::path::Path;
 
 pub struct ExecutableChecker;
@@ -19,9 +13,8 @@ impl ExecutableChecker {
 impl Checker for ExecutableChecker {
     #[cfg(any(unix, target_os = "wasi"))]
     fn is_valid(&self, path: &Path) -> bool {
-        CString::new(path.as_os_str().as_bytes())
-            .map(|c| unsafe { libc::access(c.as_ptr(), libc::X_OK) == 0 })
-            .unwrap_or(false)
+        use rustix::fs as rfs;
+        rfs::access(path, rfs::Access::EXEC_OK).is_ok()
     }
 
     #[cfg(windows)]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,8 @@
 //!
 //! ```
 
+#![forbid(unsafe_code)]
+
 mod checker;
 mod error;
 mod finder;

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -27,10 +27,8 @@ fn mk_bin(dir: &Path, path: &str, extension: &str) -> io::Result<PathBuf> {
     use std::os::unix::fs::OpenOptionsExt;
     let bin = dir.join(path).with_extension(extension);
 
-    #[cfg(target_os = "macos")]
-    let mode = libc::S_IXUSR as u32;
-    #[cfg(target_os = "linux")]
-    let mode = libc::S_IXUSR;
+    #[cfg(any(target_os = "macos", target_os = "linux"))]
+    let mode = rustix::fs::Mode::XUSR.bits();
     let mode = 0o666 | mode;
     fs::OpenOptions::new()
         .write(true)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -28,7 +28,7 @@ fn mk_bin(dir: &Path, path: &str, extension: &str) -> io::Result<PathBuf> {
     let bin = dir.join(path).with_extension(extension);
 
     #[cfg(any(target_os = "macos", target_os = "linux"))]
-    let mode = rustix::fs::Mode::XUSR.bits();
+    let mode = rustix::fs::Mode::XUSR.bits() as u32;
     let mode = 0o666 | mode;
     fs::OpenOptions::new()
         .write(true)

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -22,6 +22,7 @@ struct TestFixture {
 const SUBDIRS: &[&str] = &["a", "b", "c"];
 const BIN_NAME: &str = "bin";
 
+#[allow(clippy::unnecessary_cast)]
 #[cfg(unix)]
 fn mk_bin(dir: &Path, path: &str, extension: &str) -> io::Result<PathBuf> {
     use std::os::unix::fs::OpenOptionsExt;


### PR DESCRIPTION
This commit replaces the code using libc with equivalent code using rustix. In addition to safety, this move also removes the dependency on C code and replaces it with a syscall, which is much faster.

This PR also adds `forbid(unsafe_code)`, so that this crate shows up as unsafe-free when processed in `cargo-geiger`.

![real_rustix_patriots](https://github.com/harryfei/which-rs/assets/19805233/7f57661a-cf53-453c-874b-259fb1e2dd34)