### PR TITLE
feat: Make utility modules public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,11 +14,11 @@
 //!
 //! ```
 
-mod checker;
-mod error;
-mod finder;
+pub mod checker;
+pub mod error;
+pub mod finder;
 #[cfg(windows)]
-mod helper;
+pub mod helper;
 
 #[cfg(feature = "regex")]
 use std::borrow::Borrow;
@@ -228,7 +228,7 @@ where
     finder.find(binary_name, paths, Option::<&Path>::None, binary_checker)
 }
 
-fn build_binary_checker() -> CompositeChecker {
+pub fn build_binary_checker() -> CompositeChecker {
     CompositeChecker::new()
         .add_checker(Box::new(ExistedChecker::new()))
         .add_checker(Box::new(ExecutableChecker::new()))


### PR DESCRIPTION
Makes the function `build_binary_checker()` and modules `checker`, `error`, `finder` and `helper` public.

Context, I wish to run `which_all()` with a custom `path`. As you see `env::var_os("PATH")` is a hardcoded value. A clean solution without breaking changes is to expose low level utilities.

```rs
    let binary_checker = build_binary_checker();

    let finder = Finder::new();

    finder.find(
        binary_name,
        env::var_os("PATH"),
        Option::<&Path>::None,
        binary_checker,
    )
```