### PR TITLE
Switch from dirs crate to cargo-team maintained home crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,8 +12,8 @@ categories = ["os", "filesystem"]
 keywords = ["which", "which-rs", "unix", "command"]
 
 [dependencies]
-dirs = "5.0.1"
 either = "1.6.1"
+home = "0.5.5"
 regex = { version = "1.5.5", optional = true }
 rustix = { version = "0.38.10", default-features = false, features = ["fs", "std"] }
 

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -2,8 +2,8 @@ use crate::checker::CompositeChecker;
 use crate::error::*;
 #[cfg(windows)]
 use crate::helper::has_executable_extension;
-use dirs::home_dir;
 use either::Either;
+use home::home_dir;
 #[cfg(feature = "regex")]
 use regex::Regex;
 #[cfg(feature = "regex")]


### PR DESCRIPTION
This change is motivated by a new dependency in `dirs-sys-rs` crate (see https://github.com/dirs-dev/dirs-sys-rs/commit/e169da7af901eb621e5d244efe960f4da8ed150d) and subsequent issues (see https://github.com/dirs-dev/dirs-sys-rs/issues/21, https://github.com/dirs-dev/dirs-sys-rs/issues/23 and https://github.com/dirs-dev/dirs-rs/issues/51) where author of `dirs` crate included new small crate `option-ext` which is licensed with MPL license. MPL can be problematic to users.

This pull requests switches from `dirs` crate to `home` crate. `home` crate is maintained by the cargo team and is licensed with "MIT OR Apache-2.0" licenses including the one dependency.