### PR TITLE
feat: adaptor for WebAssembly

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -24,6 +24,11 @@ impl Checker for ExecutableChecker {
     fn is_valid(&self, _path: &Path) -> bool {
         true
     }
+
+    #[cfg(target_arch = "wasm32")]
+    fn is_valid(&self, _path: &Path) -> bool {
+        true
+    }
 }
 
 pub struct ExistedChecker;


### PR DESCRIPTION
fix the error:
When compiling WebAssembly, it gives an error that the is_valid implementation is not found.