### PR TITLE
feat: Compatible compilation to other `WebAssembly` environments

### DIFF
--- a/src/checker.rs
+++ b/src/checker.rs
@@ -24,6 +24,11 @@ impl Checker for ExecutableChecker {
     fn is_valid(&self, _path: &Path) -> bool {
         true
     }
+
+    #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
+    fn is_valid(&self, _path: &Path) -> bool {
+        true
+    }
 }
 
 pub struct ExistedChecker;


### PR DESCRIPTION
Troubleshooting a problem where `WebAssembly` compiles into a browser or `Emscripten` environment with an error that the `is_valid` implementation is not found.