### PR TITLE
build: pin home version to 0.5.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ regex = { version = "1.10.2", optional = true }
 tracing = { version = "0.1.40", default-features = false, optional = true }
 
 [target.'cfg(any(windows, unix, target_os = "redox"))'.dependencies]
-home = "0.5.9"
+home = "=0.5.9"
 
 [target.'cfg(any(unix, target_os = "wasi", target_os = "redox"))'.dependencies]
 rustix = { version = "0.38.30", default-features = false, features = ["fs", "std"] }


### PR DESCRIPTION
```
error: rustc 1.80.0 is not supported by the following package:
  home@0.5.11 requires rustc 1.81
```

Terribly they bump MSRV in a patch version ..

This refers to https://github.com/rust-lang/cargo/issues/14944.