### PR TITLE
fixes #106, bump patch version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "which"
-version = "7.0.0"
+version = "7.0.1"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Harry Fei <tiziyuanfang@gmail.com>, Jacob Kiesel <jake@bitcrafters.co>"]


### PR DESCRIPTION
Adding a proper error path here would be breaking API change, however we can pass through the tilde unaltered to avoid picking up an unintended binary.