### PR TITLE
When searching for `./script.sh`, don't return `/path/to/./script.sh`

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -53,7 +53,10 @@ impl PathExt for PathBuf {
             self
         } else {
             let mut new_path = PathBuf::from(cwd.as_ref());
-            new_path.push(self);
+            new_path.extend(
+                self.components()
+                    .skip_while(|c| matches!(c, Component::CurDir)),
+            );
             new_path
         }
     }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -124,6 +124,9 @@ impl TestFixture {
 fn _which<T: AsRef<OsStr>>(f: &TestFixture, path: T) -> which::Result<which::CanonicalPath> {
     which::CanonicalPath::new_in(path, Some(f.paths.clone()), f.tempdir.path())
 }
+fn _which_uncanonicalized<T: AsRef<OsStr>>(f: &TestFixture, path: T) -> which::Result<PathBuf> {
+    which::which_in(path, Some(f.paths.clone()), f.tempdir.path())
+}
 
 fn _which_all<'a, T: AsRef<OsStr> + 'a>(
     f: &'a TestFixture,
@@ -408,6 +411,21 @@ fn test_which_relative_leading_dot() {
     assert_eq!(
         _which(&f, "./b/bin").unwrap(),
         f.bins[4].canonicalize().unwrap()
+    );
+}
+
+#[test]
+#[cfg(unix)]
+fn test_which_relative_leading_dot_uncanonicalized() {
+    let f = TestFixture::new();
+
+    let actual = _which_uncanonicalized(&f, "./b/bin").unwrap();
+    assert_eq!(actual, f.bins[3].canonicalize().unwrap());
+
+    assert!(
+        !actual.display().to_string().contains("/./"),
+        "'{}' should not contain a CurDir component",
+        actual.display()
     );
 }
 


### PR DESCRIPTION
Previously, when you would try to find `./bin` somewhere that's in your cwd, `which` would return a file like this:
```
/path/to/./bin
```
where the `.` is not something you would expect to find, while technically valid.