### PR TITLE
Bump rustix version

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,7 +25,7 @@ tracing = { version = "0.1.40", default-features = false, optional = true }
 env_home = "0.1.0"
 
 [target.'cfg(any(unix, target_os = "wasi", target_os = "redox"))'.dependencies]
-rustix = { version = "0.38.30", default-features = false, features = ["fs", "std"] }
+rustix = { version = "1.0.5", default-features = false, features = ["fs", "std"] }
 
 [target.'cfg(windows)'.dependencies]
 winsafe = { version = "0.0.19", features = ["kernel"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -165,7 +165,7 @@ where
 ///
 /// * `regex` - A regular expression to match binaries with
 /// * `paths` - A string containing the paths to search
-///             (separated in the same way as the PATH environment variable)
+///   (separated in the same way as the PATH environment variable)
 ///
 /// # Examples
 ///


### PR DESCRIPTION
This PR bumps rustix to the 1.0 stable release. rustix 1.0 has an MSRV of 1.63 at the moment, below this crate.

Thank you for maintaining `which-rs`! 😃 