### PR TITLE
Swap dependency on rustix for dependency on libc

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -171,8 +171,8 @@ dependencies = [
 name = "which"
 version = "8.0.2"
 dependencies = [
+ "libc",
  "regex",
- "rustix",
  "tempfile",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,14 +16,14 @@ keywords = ["which", "which-rs", "unix", "command"]
 default = ["real-sys"]
 regex = ["dep:regex"]
 tracing = ["dep:tracing"]
-real-sys = ["dep:rustix"]
+real-sys = ["dep:libc"]
 
 [dependencies]
 regex = { version = "1.10.2", optional = true }
 tracing = { version = "0.1.40", default-features = false, optional = true }
 
 [target.'cfg(any(unix, target_os = "wasi", target_os = "redox"))'.dependencies]
-rustix = { version = "1.0.5", default-features = false, features = ["fs", "std"], optional = true }
+libc = { version = "0.2", optional = true }
 
 [dev-dependencies]
 tempfile = "3.9.0"

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -203,7 +203,10 @@ impl Sys for RealSys {
     #[cfg(any(unix, target_os = "wasi", target_os = "redox"))]
     fn is_valid_executable(&self, path: &Path) -> io::Result<bool> {
         use std::ffi::CString;
+        #[cfg(any(unix, target_os = "redox"))]
         use std::os::unix::ffi::OsStrExt;
+        #[cfg(target_os = "wasi")]
+        use std::os::wasi::ffi::OsStrExt;
 
         let path = CString::new(path.as_os_str().as_bytes())?;
         if unsafe { libc::access(path.as_ptr(), libc::X_OK) } == 0 {

--- a/src/sys.rs
+++ b/src/sys.rs
@@ -202,10 +202,15 @@ impl Sys for RealSys {
 
     #[cfg(any(unix, target_os = "wasi", target_os = "redox"))]
     fn is_valid_executable(&self, path: &Path) -> io::Result<bool> {
-        use rustix::fs as rfs;
-        rfs::access(path, rfs::Access::EXEC_OK)
-            .map(|_| true)
-            .map_err(|e| io::Error::from_raw_os_error(e.raw_os_error()))
+        use std::ffi::CString;
+        use std::os::unix::ffi::OsStrExt;
+
+        let path = CString::new(path.as_os_str().as_bytes())?;
+        if unsafe { libc::access(path.as_ptr(), libc::X_OK) } == 0 {
+            Ok(true)
+        } else {
+            Err(io::Error::last_os_error())
+        }
     }
 
     #[cfg(windows)]

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -33,8 +33,7 @@ mod real_sys {
         let bin = dir.join(path).with_extension(extension);
 
         #[cfg(any(target_os = "macos", target_os = "linux"))]
-        let mode = rustix::fs::Mode::XUSR.bits() as u32;
-        let mode = 0o666 | mode;
+        let mode = (0o666 | libc::S_IXUSR) as u32;
         fs::OpenOptions::new()
             .write(true)
             .create(true)


### PR DESCRIPTION
I made an attempt at not even depending on `libc`, however I feel this would be too much of a risk since `libc` supports a wide variety of targets. In any case, `rustix` uses `libc` as well, so by going this path we trim our dependency tree.