### PR TITLE
feat: use catch-all cfg for `is_valid_executable` on unsupported targets

### DIFF
--- a/src/sys.rs
+++ b/src/sys.rs
@@ -236,6 +236,11 @@ impl Sys for RealSys {
             }
         }
     }
+
+    #[cfg(not(any(unix, windows, target_os = "wasi", target_os = "redox")))]
+    fn is_valid_executable(&self, _path: &Path) -> io::Result<bool> {
+        Ok(false)
+    }
 }
 
 impl<T> Sys for &T


### PR DESCRIPTION
# Problem

On targets that are not Unix, Windows, WASI, or Redox (e.g. zkVM environments), `RealSys::is_valid_executable` has no implementation, causing a hard compile error:

```
  error[E0046]: not all trait items implemented, missing: `is_valid_executable`
    --> which-8.0.2/src/sys.rs:126:1
     |
  89 |     fn is_valid_executable(&self, path: &Path) -> io::Result<bool>;
     |     --------------------------------------------------------------- `is_valid_executable` from trait
  ...
  126 | impl Sys for RealSys {
      | ^^^^^^^^^^^^^^^^^^^^ missing `is_valid_executable` in implementation
```

This was observed when compiling against `sp1-zkvm`, but affects any target that doesn't satisfy `unix`, `windows`, `target_os = "wasi"`, or `target_os = "redox"`.

# Change
  
Add a general fallback using the complement of the existing `cfg` conditions:
```
  #[cfg(not(any(unix, windows, target_os = "wasi", target_os = "redox")))]
  fn is_valid_executable(&self, _path: &Path) -> io::Result<bool> {
      Ok(false)
  }
```

Rather than enumerating every exotic target, this ensures `RealSys` always has a complete `Sys` implementation, returning `Ok(false)` on platforms where executable checking is not meaningful.