### PR TITLE
feat: emit NonFatalError on Windows if PATHEXT not populated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## 8.0.4
+
+- On Windows we now emit a `NonFatalError` if the `PATHEXT` environment variable is not populated, and the query did not specify a file extension.
+
 ## 8.0.3
 
 - Add fallback implementation of `is_valid_executable` allowing `which-rs` to compile on targets which are not Unix, Windows, WASI, or Redox. Thanks [@pmikolajczyk41](https://github.com/pmikolajczyk41) for your contribution to which!

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -169,7 +169,7 @@ dependencies = [
 
 [[package]]
 name = "which"
-version = "8.0.3"
+version = "8.0.4"
 dependencies = [
  "libc",
  "regex",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "which"
-version = "8.0.3"
+version = "8.0.4"
 edition = "2021"
 rust-version = "1.70"
 authors = ["Harry Fei <tiziyuanfang@gmail.com>, Jacob Kiesel <jake@bitcrafters.co>"]

--- a/src/error.rs
+++ b/src/error.rs
@@ -31,6 +31,10 @@ impl fmt::Display for Error {
 #[non_exhaustive]
 pub enum NonFatalError {
     Io(io::Error),
+    /// The Windows PATHEXT environment variable was not populated with any usable extensions,
+    /// and the query did not specify a file extension. This is technically legal but probably not
+    /// intentional.
+    PathExtNotPopulated,
 }
 
 impl std::error::Error for NonFatalError {}
@@ -39,6 +43,7 @@ impl fmt::Display for NonFatalError {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
             Self::Io(e) => write!(f, "{e}"),
+            Self::PathExtNotPopulated => write!(f, "PATHEXT environment variable is not populated, and the query did not specify a file extension"),
         }
     }
 }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -123,12 +123,20 @@ struct WhichFindIterator<TSys: Sys, F: NonFatalErrorHandler> {
 }
 
 impl<TSys: Sys, F: NonFatalErrorHandler> WhichFindIterator<TSys, F> {
-    pub fn new_cwd(binary_name: PathBuf, cwd: &Path, sys: TSys, nonfatal_error_handler: F) -> Self {
+    pub fn new_cwd(
+        binary_name: PathBuf,
+        cwd: &Path,
+        sys: TSys,
+        mut nonfatal_error_handler: F,
+    ) -> Self {
         let path_extensions = if sys.is_windows() {
             sys.env_windows_path_ext()
         } else {
             Cow::Borrowed(Default::default())
         };
+        if sys.is_windows() && path_extensions.is_empty() && binary_name.extension().is_none() {
+            nonfatal_error_handler.handle(NonFatalError::PathExtNotPopulated);
+        }
         Self {
             sys,
             paths: PathsIter {
@@ -144,13 +152,16 @@ impl<TSys: Sys, F: NonFatalErrorHandler> WhichFindIterator<TSys, F> {
         binary_name: PathBuf,
         paths: Vec<PathBuf>,
         sys: TSys,
-        nonfatal_error_handler: F,
+        mut nonfatal_error_handler: F,
     ) -> Self {
         let path_extensions = if sys.is_windows() {
             sys.env_windows_path_ext()
         } else {
             Cow::Borrowed(Default::default())
         };
+        if sys.is_windows() && path_extensions.is_empty() && binary_name.extension().is_none() {
+            nonfatal_error_handler.handle(NonFatalError::PathExtNotPopulated);
+        }
 
         let paths = paths.iter();
 

--- a/tests/windows_no_pathext.rs
+++ b/tests/windows_no_pathext.rs
@@ -1,0 +1,36 @@
+//! A tiny test scaffold to keep the `set_env` call in this test isolated to its own process.
+#![allow(clippy::disallowed_methods)]
+
+/// Ensure that if PATHEXT is not populated, and the query is missing an extension, that an
+/// appropriate NonFatalError is emitted.
+#[test]
+#[cfg(all(windows, feature = "real-sys"))]
+fn windows_no_pathext_nonfatal_error() {
+    use std::ffi::OsString;
+    use which::{NonFatalError, WhichConfig};
+    // This runs on Windows only and so is guaranteed to be safe. Still this shouldn't be allowed to
+    // interfere with the other tests, so it is isolated to its own process.
+    #[allow(unused_unsafe)] // Required for Rust 1.70.
+    unsafe {
+        std::env::set_var("PATHEXT", "");
+    }
+
+    let this_executable = std::env::current_exe().unwrap();
+    let new_name = this_executable.parent().unwrap().join("test_executable");
+    std::fs::copy(&this_executable, &new_name).unwrap();
+    let mut nonfatal_errors = Vec::new();
+    WhichConfig::new()
+        .nonfatal_error_handler(|e| {
+            nonfatal_errors.push(e);
+        })
+        .binary_name(OsString::from("test_executable"))
+        .custom_path_list(this_executable.parent().unwrap().as_os_str().to_os_string())
+        .first_result()
+        .unwrap();
+    std::fs::remove_file(new_name).unwrap();
+    assert_eq!(nonfatal_errors.len(), 1);
+    assert!(matches!(
+        nonfatal_errors[0],
+        NonFatalError::PathExtNotPopulated
+    ));
+}


### PR DESCRIPTION
Fixes #123 

If this situation is detected, `which` will now send a `NonFatalError::PathExtNotPopulated` to the user provided `nonfatal_error_handler`. This makes it possible to detect and warn about this situation.