### PR TITLE
Fix absolute path lookup when cwd is disabled

### DIFF
--- a/src/finder.rs
+++ b/src/finder.rs
@@ -77,6 +77,9 @@ impl<TSys: Sys> Finder<TSys> {
         );
 
         let ret = match cwd {
+            _ if path.is_absolute() => {
+                WhichFindIterator::new_cwd(path, Path::new(""), self.sys, nonfatal_error_handler)
+            }
             Some(cwd) if path.has_separator() => {
                 WhichFindIterator::new_cwd(path, cwd.as_ref(), self.sys, nonfatal_error_handler)
             }

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -78,7 +78,7 @@ impl<TSys: Sys> Finder<TSys> {
 
         let ret = match cwd {
             _ if path.is_absolute() => {
-                WhichFindIterator::new_cwd(path, Path::new(""), self.sys, nonfatal_error_handler)
+                WhichFindIterator::new_path(path, self.sys, nonfatal_error_handler)
             }
             Some(cwd) if path.has_separator() => {
                 WhichFindIterator::new_cwd(path, cwd.as_ref(), self.sys, nonfatal_error_handler)
@@ -126,12 +126,7 @@ struct WhichFindIterator<TSys: Sys, F: NonFatalErrorHandler> {
 }
 
 impl<TSys: Sys, F: NonFatalErrorHandler> WhichFindIterator<TSys, F> {
-    pub fn new_cwd(
-        binary_name: PathBuf,
-        cwd: &Path,
-        sys: TSys,
-        mut nonfatal_error_handler: F,
-    ) -> Self {
+    pub fn new_path(binary_name: PathBuf, sys: TSys, mut nonfatal_error_handler: F) -> Self {
         let path_extensions = if sys.is_windows() {
             sys.env_windows_path_ext()
         } else {
@@ -143,12 +138,16 @@ impl<TSys: Sys, F: NonFatalErrorHandler> WhichFindIterator<TSys, F> {
         Self {
             sys,
             paths: PathsIter {
-                paths: vec![binary_name.to_absolute(cwd)].into_iter(),
+                paths: vec![binary_name].into_iter(),
                 current_path_with_index: None,
                 path_extensions,
             },
             nonfatal_error_handler,
         }
+    }
+
+    pub fn new_cwd(binary_name: PathBuf, cwd: &Path, sys: TSys, nonfatal_error_handler: F) -> Self {
+        Self::new_path(binary_name.to_absolute(cwd), sys, nonfatal_error_handler)
     }
 
     pub fn new_paths(

--- a/src/finder.rs
+++ b/src/finder.rs
@@ -376,18 +376,14 @@ impl<TSys: Sys, B: Borrow<Regex>, F: NonFatalErrorHandler> Iterator
                     }
                 }
             } else {
-                let path = self.paths.next();
-                if let Some(path) = path {
-                    match self.sys.read_dir(&path) {
-                        Ok(new_read_dir_iter) => {
-                            self.current_read_dir_iter = Some(new_read_dir_iter);
-                        }
-                        Err(e) => {
-                            self.nonfatal_error_handler.handle(NonFatalError::Io(e));
-                        }
+                let path = self.paths.next()?;
+                match self.sys.read_dir(&path) {
+                    Ok(new_read_dir_iter) => {
+                        self.current_read_dir_iter = Some(new_read_dir_iter);
                     }
-                } else {
-                    return None;
+                    Err(e) => {
+                        self.nonfatal_error_handler.handle(NonFatalError::Io(e));
+                    }
                 }
             }
         }

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -863,6 +863,19 @@ mod in_memory {
     }
 
     #[test]
+    fn absolute_path_works_without_cwd_or_path_list() {
+        let mut sys = InMemorySys::new();
+        sys.write_executable("/sub/dir/exec");
+        let config = which::WhichConfig::new_with_sys(sys)
+            .system_cwd(false)
+            .binary_name(OsString::from("/sub/dir/exec"));
+
+        let result = config.first_result().unwrap();
+
+        assert_eq!(result, PathBuf::from("/sub/dir/exec"));
+    }
+
+    #[test]
     fn symlink() {
         let mut sys = InMemorySys::new();
         sys.set_env_var("PATH", "/sub/dir1/");

--- a/tests/basic.rs
+++ b/tests/basic.rs
@@ -322,6 +322,19 @@ mod real_sys {
 
     #[test]
     #[cfg(windows)]
+    fn test_which_global_absolute_without_path_list() {
+        let f = TestFixture::new();
+
+        let result = which::which_in_global(&f.bins[4], Option::<&OsStr>::None)
+            .unwrap()
+            .next()
+            .unwrap();
+
+        assert_eq!(result, f.bins[4]);
+    }
+
+    #[test]
+    #[cfg(windows)]
     fn test_which_absolute_path_case() {
         // Test that an absolute path with an uppercase extension
         // is accepted.
@@ -863,6 +876,7 @@ mod in_memory {
     }
 
     #[test]
+    #[cfg(not(windows))]
     fn absolute_path_works_without_cwd_or_path_list() {
         let mut sys = InMemorySys::new();
         sys.write_executable("/sub/dir/exec");


### PR DESCRIPTION
## Summary

Fix absolute path lookups when `cwd` resolution is disabled.

Previously, `Finder::find` only handled paths with separators through the direct path-checking path when a `cwd` was available. This meant absolute paths passed through APIs such as `which_global` or `WhichConfig::system_cwd(false)` could incorrectly fall back to PATH-based searching and fail with `CannotGetCurrentDirAndPathListEmpty` when no PATH list was available.

This change makes absolute paths bypass PATH lookup and use the existing direct path validation flow.

## Motivation

The public docs for `which_global` say that an absolute path should be returned if it exists and is executable. Absolute paths do not need a cwd or PATH list, so disabling cwd resolution should not prevent them from being checked.

## Tests

- `cargo test --all-features absolute_path_works_without_cwd_or_path_list -- --nocapture`
- `cargo fmt --check`
- `cargo clippy --all-features --all-targets -- -D warnings`
- `cargo test --all-features`
- `cargo test --workspace --no-default-features`